### PR TITLE
Added missing `CLSwiftTests.allTests` member

### DIFF
--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,6 +1,16 @@
 import XCTest
 @testable import CLSwiftTests
 
+extension CLSwiftTests {
+    static var allTests: [(String, (CLSwiftTests) -> () throws -> Void)] = [
+        ("testEmpty", testEmpty),
+        ("testLowerThanMinimumArgumentsInputLength", testLowerThanMinimumArgumentsInputLength),
+        ("testGreaterThanMaximumArgumentsInputLength", testGreaterThanMaximumArgumentsInputLength),
+        ("testWithAssociatedArg", testWithAssociatedArg),
+        ("testFailureWithFlags", testFailureWithFlags),
+    ]
+}
+
 XCTMain([
     testCase(CLSwiftTests.allTests),
 ])


### PR DESCRIPTION
* Added through an extension on `LinuxMain.swift`.
* Tested already under Linux.
* At the time of this writing, all test pass on Linux (good job everyone!).